### PR TITLE
trigger script even if no song recv - to allow for mpc clear

### DIFF
--- a/mpd_trigger.c
+++ b/mpd_trigger.c
@@ -262,7 +262,7 @@ void main_loop() {
         if (!idle_info) MAINLOOP_ERROR;
         if (idle_info == MPD_IDLE_PLAYER)
         {
-            int et, tt;
+            int et, tt, c = 0;
             mpd_send_status(conn);
             status = mpd_recv_status(conn);
             if (!status) MAINLOOP_ERROR;
@@ -287,7 +287,9 @@ void main_loop() {
                 if (album) free(album);
                 if (track) free(track);
                 mpd_song_free(song);
+                c = 1;
             }
+            if (!c) trigger(filter(trigger_command));
         }
     }
 }


### PR DESCRIPTION
First of all thanks for this script, very useful - compiled on RPI4 and using it to control inputs on external DAC via IR script so when mpd playback starts and stops it always returns to the default input.

I noticed that although events are generated most of the time, if I issue ‘mpc clear’ it detects the event but fails to trigger the script. I don’t really understand C code, but this hacky fix seems to trigger the script even if ‘mpc clear’ is issued. It might introduce other errors, and I’m sure there’s a more elegant way, but it seems to work for my purposes :)